### PR TITLE
Correct type in instructions.md

### DIFF
--- a/exercises/concept/cater-waiter/.docs/instructions.md
+++ b/exercises/concept/cater-waiter/.docs/instructions.md
@@ -134,7 +134,7 @@ Each `<CATEGORY>_INTERSECTIONS` is a `set` of ingredients that appear in more th
 Using set operations, your function should return a `set` of "singleton" ingredients (_ingredients appearing in only one dish in the category_).
 
 ```python
-from sets_categories_data import example_dishes, EXAMPLE_INTERSECTIONS
+from sets_categories_data import example_dishes, EXAMPLE_INTERSECTION
 
 >>> singleton_ingredients(example_dishes, EXAMPLE_INTERSECTION)
 ...


### PR DESCRIPTION
Change "EXAMPLE_INTERSECTIONS" to "EXAMPLE_INTERSECTION" in the example data import statement for problem 7

"EXAMPLE_INTERSECTIONS" does not exist in sets_categories_data.py; "EXAMPLE_INTERSECTION" does